### PR TITLE
fix: add suffix to LB security group

### DIFF
--- a/modules/lb/security.tf
+++ b/modules/lb/security.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "load_balancer_sg" {
-  name        = "load-balancer-sg"
+  name        = "load_balancer_sg_${var.suffix}"
   description = "Allow HTTP and HTTPS traffic to the load balancer"
   vpc_id      = var.vpc_id
 }


### PR DESCRIPTION
I've added the suffix, and switches from `-` to `_` as the separator in the name for consistency with the infra module.