### PR TITLE
fix: make server_domain naming consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Check out the [Terraform](https://developer.hashicorp.com/terraform/language/bac
 
 ```hcl
 locals {
-  region = "eu-west-1"
+  region            = "eu-west-1"
   spacelift_version = "v3.4.0"
   website_domain    = "spacelift.mycorp.io"
   website_endpoint  = "https://${local.website_domain}"
@@ -25,8 +25,8 @@ locals {
 module "spacelift_infra" {
   source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.0.0"
 
-  region         = local.region
-  default_tags   = {"app" = "spacelift-selfhosted-infra", "env" = "dev"}
+  region           = local.region
+  default_tags     = {"app" = "spacelift-selfhosted-infra", "env" = "dev"}
   website_endpoint = local.website_endpoint
 }
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ Check out the [Terraform](https://developer.hashicorp.com/terraform/language/bac
 locals {
   region = "eu-west-1"
   spacelift_version = "v3.4.0"
-  website_domain    = "https://spacelift.mycorp.io"
-  mqtt_domain       = "tls://spacelift-mqtt.mycorp.io:1984" # Must start with `tls://` and end with a port number
+  website_domain    = "spacelift.mycorp.io"
+  website_endpoint  = "https://${local.website_domain}"
+  mqtt_domain       = "spacelift-mqtt.mycorp.io"
+  mqtt_endpoint     = "tls://${local.mqtt_domain}:1984"
 }
 
 module "spacelift_infra" {
@@ -25,7 +27,7 @@ module "spacelift_infra" {
 
   region         = local.region
   default_tags   = {"app" = "spacelift-selfhosted-infra", "env" = "dev"}
-  website_domain = local.website_domain
+  website_endpoint = local.website_endpoint
 }
 
 module "spacelift_services" {
@@ -36,7 +38,7 @@ module "spacelift_services" {
   unique_suffix        = module.spacelift_infra.unique_suffix
   kms_key_arn          = module.spacelift_infra.kms_key_arn
   server_domain        = local.website_domain
-  mqtt_broker_endpoint = local.mqtt_domain
+  mqtt_broker_endpoint = local.mqtt_endpoint
 
   license_token = "<your-license-token-issued-by-Spacelift>"
 

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -1,9 +1,10 @@
 locals {
-  backend_image = "${var.backend_image}:${var.backend_image_tag}"
+  webhooks_endpoint = "https://${join("/", [var.server_domain, "webhooks"])}"
+  backend_image     = "${var.backend_image}:${var.backend_image_tag}"
   shared_envs = [
     {
       name  = "SERVER_DOMAIN"
-      value = trimprefix(var.server_domain, "https://")
+      value = var.server_domain
     },
     {
       name  = "MQTT_BROKER_TYPE"
@@ -150,7 +151,7 @@ resource "aws_ecs_task_definition" "server" {
         },
         {
           name  = "WEBHOOKS_ENDPOINT"
-          value = join("/", [var.server_domain, "webhooks"])
+          value = local.webhooks_endpoint
         }
       ])
     }

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -1,5 +1,5 @@
 locals {
-  webhooks_endpoint = "https://${join("/", [var.server_domain, "webhooks"])}"
+  webhooks_endpoint = "https://${var.server_domain}/webhooks"
   backend_image     = "${var.backend_image}:${var.backend_image_tag}"
   shared_envs = [
     {

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -131,7 +131,11 @@ variable "mqtt_broker_port" {
 
 variable "server_domain" {
   type        = string
-  description = "The domain of the server service."
+  description = "The domain of the server service. This should be the domain name without the protocol, for example spacelift.example.com, not https://spacelift.example.com."
+  validation {
+    condition     = !startswith(var.server_domain, "http://") && !startswith(var.server_domain, "https://")
+    error_message = "server_domain should not include a protocol ('http://' or 'https://')"
+  }
 }
 
 variable "mqtt_broker_endpoint" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,11 @@ variable "mqtt_broker_endpoint" {
 
 variable "server_domain" {
   type        = string
-  description = "The domain of the server service with protocol. For example: https://spacelift.mycorp.com"
+  description = "The domain of the server service. This should be the domain name without the protocol, for example spacelift.example.com, not https://spacelift.example.com."
+  validation {
+    condition     = !startswith(var.server_domain, "http://") && !startswith(var.server_domain, "https://")
+    error_message = "server_domain should not include a protocol ('http://' or 'https://')"
+  }
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
I've adjusted how we're using the `server_domain` variable so that we expect a domain name to be supplied, not a full endpoint. This means we can avoid trimming the protocol off when setting the `SERVER_DOMAIN` env var, and can add a protocol to the webhooks endpoint.