### PR TITLE
fix: adjust encryption variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ module "spacelift_services" {
 
   license_token = "<your-license-token-issued-by-Spacelift>"
 
-  encryption_type                  = "kms"
-  encryption_kms_encryption_key_id = module.spacelift_infra.encryption_key_arn
-  jwt_signing_key_arn              = module.spacelift_infra.jwt_signing_key_arn
+  encryption_type        = "kms"
+  kms_encryption_key_arn = module.spacelift_infra.kms_encryption_key_arn
+  kms_signing_key_arn    = module.spacelift_infra.kms_signing_key_arn
 
   database_url           = format("postgres://%s:%s@%s:5432/spacelift?statement_cache_capacity=0", module.spacelift_infra.rds_username, module.spacelift_infra.rds_password, module.spacelift_infra.rds_cluster_endpoint)
   database_read_only_url = format("postgres://%s:%s@%s:5432/spacelift?statement_cache_capacity=0", module.spacelift_infra.rds_username, module.spacelift_infra.rds_password, module.spacelift_infra.rds_cluster_reader_endpoint)

--- a/main.tf
+++ b/main.tf
@@ -78,11 +78,11 @@ module "ecs" {
   workspace_bucket_arn                 = "arn:${data.aws_partition.current.partition}:s3:::${var.workspace_bucket_name}"
   workspace_bucket_name                = var.workspace_bucket_name
 
-  encryption_type                  = var.encryption_type
-  encryption_kms_encryption_key_id = var.encryption_kms_encryption_key_id
-  encryption_rsa_private_key       = var.encryption_rsa_private_key
-  jwt_signing_key_arn              = var.jwt_signing_key_arn
-  kms_key_arn                      = var.kms_key_arn
+  encryption_type        = var.encryption_type
+  rsa_private_key        = var.rsa_private_key
+  kms_encryption_key_arn = var.kms_encryption_key_arn
+  kms_signing_key_arn    = var.kms_signing_key_arn
+  kms_key_arn            = var.kms_key_arn
 
   execution_role_arn = var.execution_role_arn
 

--- a/modules/ecs/iam_scheduler.tf
+++ b/modules/ecs/iam_scheduler.tf
@@ -47,23 +47,23 @@ resource "aws_iam_policy" "scheduler" {
           Resource = [var.kms_key_arn]
         }
       ],
-      var.encryption_kms_encryption_key_id == null ? [] : [{
+      var.kms_encryption_key_arn == null ? [] : [{
         Effect = "Allow"
         Action = [
           "kms:Decrypt",
           "kms:Encrypt",
           "kms:GenerateDataKey*",
         ]
-        Resource = [var.encryption_kms_encryption_key_id]
+        Resource = [var.kms_encryption_key_arn]
       }],
-      var.jwt_signing_key_arn == null ? [] : [{
+      var.kms_signing_key_arn == null ? [] : [{
         Effect = "Allow"
         Action = [
           "kms:GetPublicKey",
           "kms:Sign",
           "kms:Verify",
         ]
-        Resource = [var.jwt_signing_key_arn]
+        Resource = [var.kms_signing_key_arn]
       }]
     )
   })

--- a/modules/ecs/iam_server.tf
+++ b/modules/ecs/iam_server.tf
@@ -160,23 +160,23 @@ resource "aws_iam_policy" "drain-and-server" {
         Resource = [var.kms_key_arn]
       }
       ],
-      var.encryption_kms_encryption_key_id == null ? [] : [{
+      var.kms_encryption_key_arn == null ? [] : [{
         Effect = "Allow"
         Action = [
           "kms:Decrypt",
           "kms:Encrypt",
           "kms:GenerateDataKey*",
         ]
-        Resource = [var.encryption_kms_encryption_key_id]
+        Resource = [var.kms_encryption_key_arn]
       }],
-      var.jwt_signing_key_arn == null ? [] : [{
+      var.kms_signing_key_arn == null ? [] : [{
         Effect = "Allow"
         Action = [
           "kms:GetPublicKey",
           "kms:Sign",
           "kms:Verify",
         ]
-        Resource = [var.jwt_signing_key_arn]
+        Resource = [var.kms_signing_key_arn]
       }]
     )
   })

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -36,15 +36,15 @@ locals {
     },
     {
       name  = "ENCRYPTION_RSA_PRIVATE_KEY"
-      value = var.encryption_rsa_private_key
+      value = var.rsa_private_key
     },
     {
       name  = "ENCRYPTION_KMS_ENCRYPTION_KEY_ID"
-      value = var.encryption_kms_encryption_key_id
+      value = var.kms_encryption_key_arn
     },
     {
       name  = "ENCRYPTION_KMS_SIGNING_KEY_ID"
-      value = var.jwt_signing_key_arn
+      value = var.kms_signing_key_arn
     },
     {
       name  = "MESSAGE_QUEUE_TYPE"

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -178,17 +178,17 @@ variable "encryption_type" {
   }
 }
 
-variable "encryption_rsa_private_key" {
+variable "rsa_private_key" {
   type        = string
   description = "The b64 encoded RSA private key to use for encryption. Required if encryption_type is 'rsa'."
 }
 
-variable "encryption_kms_encryption_key_id" {
+variable "kms_encryption_key_arn" {
   type        = string
   description = "The KMS encryption key ID to use for encryption. Required if encryption_type is 'kms'."
 }
 
-variable "jwt_signing_key_arn" {
+variable "kms_signing_key_arn" {
   type        = string
   description = "The ARN of the KMS key to use for signing JWT tokens. Required if encryption_type is 'kms'."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -186,19 +186,19 @@ variable "encryption_type" {
   }
 }
 
-variable "encryption_kms_encryption_key_id" {
-  type        = string
-  description = "The KMS key ID to use for in-app encryption. Required if encryption_type is 'kms'."
-  default     = ""
-}
-
-variable "encryption_rsa_private_key" {
+variable "rsa_private_key" {
   type        = string
   description = "The base64 encoded RSA private key to use for in-app encryption. Required if encryption_type is 'rsa'."
   default     = ""
 }
 
-variable "jwt_signing_key_arn" {
+variable "kms_encryption_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key to use for in-app encryption. Required if encryption_type is 'kms'."
+  default     = ""
+}
+
+variable "kms_signing_key_arn" {
   type        = string
   description = "The ARN of the KMS key to use for signing JWT tokens. Required if encryption_type is 'kms'."
 }


### PR DESCRIPTION
- I've tried to make the naming of the encryption variables a little less verbose by removing the double `encryption`.
- I've switched the `_id` suffix to `_arn` for the encryption key to make it clearer that we need the ARN.
- I renamed `jwt_signing_key_arn` to `kms_signing_key_arn` to indicate that it's the KMS key to use for signing when using KMS instead of RSA.