### PR TITLE
Add `additional_env_vars` variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,7 @@ module "ecs" {
   server_target_group_arn     = module.lb.server_target_group_arn
   server_container_definition = var.server_container_definition
 
+  additional_env_vars                   = var.additional_env_vars
   observability_vendor                  = var.observability_vendor
   enable_automatic_usage_data_reporting = var.enable_automatic_usage_data_reporting
 }

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -1,7 +1,7 @@
 locals {
   webhooks_endpoint = "https://${var.server_domain}/webhooks"
   backend_image     = "${var.backend_image}:${var.backend_image_tag}"
-  shared_envs = [
+  shared_envs = concat(var.additional_env_vars, [
     {
       name  = "AWS_ACCOUNT_ID",
       value = var.aws_account_id
@@ -117,8 +117,9 @@ locals {
     {
       name  = "OBSERVABILITY_VENDOR"
       value = var.observability_vendor
-    }
-  ]
+    },
+    ]
+  )
 }
 
 resource "aws_ecs_task_definition" "server" {

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -362,6 +362,15 @@ variable "kms_key_arn" {
   description = "The ARN of the KMS key used for encrypting AWS resources (ECR, S3, etc.)."
 }
 
+variable "additional_env_vars" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "Additional environment variables to pass to the containers."
+  default     = []
+}
+
 variable "enable_automatic_usage_data_reporting" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -345,6 +345,15 @@ variable "observability_vendor" {
   default = "Disabled"
 }
 
+variable "additional_env_vars" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "Additional environment variables to pass to the containers."
+  default     = []
+}
+
 variable "enable_automatic_usage_data_reporting" {
   type        = bool
   default     = false


### PR DESCRIPTION
In case we need to inject variables, such as feature flags for beta features.

Tested on our test env:
<img width="488" alt="image" src="https://github.com/user-attachments/assets/8ab58fc6-1263-475e-857e-8935191b775a" />
