### PR TITLE
Allow using IoT as MQTT broker, allow using SQS as message queue (for sh v2 compatibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ This module supports two types of MQTT brokers:
    - Uses AWS IoT Core as the MQTT broker
    - No separate load balancer is created
    - Set in your configuration with: `mqtt_broker_type = "iotcore"`
+   - **Important**: when the `mqtt_broker_type` is set to `iotcore`, the message queue type must be SQS, hence the `sqs_queues` variable is a must. This is because the AWS IoT Core broker publishes message to SQS queues.
 
 ### Message Queue Types
 
@@ -219,6 +220,7 @@ The Spacelift server supports two types of message queues:
 2. **AWS SQS (MESSAGE_QUEUE_TYPE = "sqs")**
    - Uses AWS SQS for message queuing
    - Requires the `sqs_queues` variable with queue names
+   - If you set the `mqtt_broker_type` to `iotcore`, the message queue type must be SQS, hence the `sqs_queues` variable is a must.
    - Automatically fetches ARNs and URLs using data sources
    - Configure in your module with:
    ```hcl

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -1,0 +1,47 @@
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+data "aws_iot_endpoint" "iot" {
+  count         = var.mqtt_broker_type == "iotcore" ? 1 : 0
+  endpoint_type = "iot:Data-ATS"
+}
+
+data "aws_sqs_queue" "deadletter" {
+  count = var.sqs_queues != null ? 1 : 0
+  name  = var.sqs_queues.deadletter
+}
+
+data "aws_sqs_queue" "deadletter_fifo" {
+  count = var.sqs_queues != null ? 1 : 0
+  name  = var.sqs_queues.deadletter_fifo
+}
+
+data "aws_sqs_queue" "async_jobs" {
+  count = var.sqs_queues != null ? 1 : 0
+  name  = var.sqs_queues.async_jobs
+}
+
+data "aws_sqs_queue" "events_inbox" {
+  count = var.sqs_queues != null ? 1 : 0
+  name  = var.sqs_queues.events_inbox
+}
+
+data "aws_sqs_queue" "async_jobs_fifo" {
+  count = var.sqs_queues != null ? 1 : 0
+  name  = var.sqs_queues.async_jobs_fifo
+}
+
+data "aws_sqs_queue" "cronjobs" {
+  count = var.sqs_queues != null ? 1 : 0
+  name  = var.sqs_queues.cronjobs
+}
+
+data "aws_sqs_queue" "webhooks" {
+  count = var.sqs_queues != null ? 1 : 0
+  name  = var.sqs_queues.webhooks
+}
+
+data "aws_sqs_queue" "iot" {
+  count = var.sqs_queues != null ? 1 : 0
+  name  = var.sqs_queues.iot
+}

--- a/modules/ecs/container_definitions.tf
+++ b/modules/ecs/container_definitions.tf
@@ -36,6 +36,10 @@ locals {
           value = var.admin_password
         },
         {
+          name  = "AWS_S3_US_EAST_1_REGIONAL_ENDPOINT"
+          value = "regional"
+        },
+        {
           name  = "FEATURE_FLAG_SELF_HOSTED_V3_INSTALLATION_FLOW"
           value = "true"
         },

--- a/modules/ecs/container_definitions.tf
+++ b/modules/ecs/container_definitions.tf
@@ -6,14 +6,18 @@ locals {
       command   = ["spacelift", "backend", "server"]
       essential = true
       image     = local.backend_image
-      portMappings = [
-        {
-          containerPort = var.server_port
-        },
-        {
-          containerPort = var.mqtt_broker_port
-        }
-      ]
+      portMappings = concat(
+        [
+          {
+            containerPort = var.server_port
+          }
+        ],
+        var.mqtt_broker_port != 0 ? [
+          {
+            containerPort = var.mqtt_broker_port
+          }
+        ] : []
+      )
       ulimits = [
         {
           name      = "nofile"
@@ -58,20 +62,37 @@ locals {
         }
       ]
       logConfiguration = var.drain_log_configuration
-      environment = concat(local.shared_envs, [
-        {
-          name  = "LAUNCHER_IMAGE"
-          value = var.launcher_image
-        },
-        {
-          name  = "LAUNCHER_IMAGE_TAG"
-          value = var.launcher_image_tag
-        },
-        {
-          name  = "SPACELIFT_PUBLIC_API"
-          value = var.enable_automatic_usage_data_reporting ? local.spacelift_public_api : ""
-        }
-      ])
+      environment = concat(
+        local.shared_envs,
+        [
+          {
+            name  = "LAUNCHER_IMAGE"
+            value = var.launcher_image
+          },
+          {
+            name  = "LAUNCHER_IMAGE_TAG"
+            value = var.launcher_image_tag
+          },
+          {
+            name  = "SPACELIFT_PUBLIC_API"
+            value = var.enable_automatic_usage_data_reporting ? local.spacelift_public_api : ""
+          }
+        ],
+        var.sqs_queues != null ? [
+          {
+            name  = "MESSAGE_QUEUE_SQS_DLQ_URL"
+            value = var.sqs_queues.deadletter_url
+          },
+          {
+            name  = "MESSAGE_QUEUE_SQS_DLQ_FIFO_URL"
+            value = var.sqs_queues.deadletter_fifo_url
+          },
+          {
+            name  = "MESSAGE_QUEUE_SQS_IOT_URL"
+            value = var.sqs_queues.iot_url
+          }
+        ] : []
+      )
       secrets = var.sensitive_env_vars
     }
   ])

--- a/modules/ecs/iam_submodule.tf
+++ b/modules/ecs/iam_submodule.tf
@@ -20,4 +20,7 @@ module "iam_roles_and_policies" {
   uploads_bucket_name                  = var.uploads_bucket_name
   user_uploaded_workspaces_bucket_name = var.user_uploaded_workspaces_bucket_name
   workspace_bucket_name                = var.workspace_bucket_name
+
+  sqs_queues = var.sqs_queues
+  iot_topic  = var.iot_topic
 }

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -49,10 +49,13 @@ resource "aws_ecs_service" "server" {
     container_port   = var.server_port
   }
 
-  load_balancer {
-    target_group_arn = var.mqtt_server_target_group_arn
-    container_name   = "server"
-    container_port   = var.mqtt_broker_port
+  dynamic "load_balancer" {
+    for_each = var.mqtt_broker_type == "mqtt" ? [1] : []
+    content {
+      target_group_arn = var.mqtt_server_target_group_arn
+      container_name   = "server"
+      container_port   = var.mqtt_broker_port
+    }
   }
 }
 

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -19,6 +19,10 @@ locals {
         value = var.aws_region
       },
       {
+        name  = "AWS_PARTITION"
+        value = var.aws_partition
+      },
+      {
         name  = "ENVIRONMENT"
         value = "prod"
       },

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -1,115 +1,119 @@
+
 locals {
   webhooks_endpoint = "https://${var.server_domain}/webhooks"
   backend_image     = "${var.backend_image}:${var.backend_image_tag}"
-  shared_envs = concat(var.additional_env_vars, [
-    {
-      name  = "AWS_ACCOUNT_ID",
-      value = var.aws_account_id
-    },
-    {
-      name  = "AWS_DEFAULT_REGION",
-      value = var.aws_region
-    },
-    {
-      name  = "AWS_REGION",
-      value = var.aws_region
-    },
-    {
-      name  = "ENVIRONMENT",
-      value = "prod"
-    },
-    {
-      name  = "SERVER_DOMAIN"
-      value = var.server_domain
-    },
-    {
-      name  = "MQTT_BROKER_TYPE"
-      value = "builtin"
-    },
-    {
-      name  = "MQTT_BROKER_ENDPOINT"
-      value = var.mqtt_broker_endpoint
-    },
-    {
-      name  = "ENCRYPTION_TYPE"
-      value = var.encryption_type
-    },
-    {
-      name  = "ENCRYPTION_RSA_PRIVATE_KEY"
-      value = var.rsa_private_key
-    },
-    {
-      name  = "ENCRYPTION_KMS_ENCRYPTION_KEY_ID"
-      value = var.kms_encryption_key_arn
-    },
-    {
-      name  = "ENCRYPTION_KMS_SIGNING_KEY_ID"
-      value = var.kms_signing_key_arn
-    },
-    {
-      name  = "MESSAGE_QUEUE_TYPE"
-      value = "postgres"
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_DELIVERIES"
-      value = var.deliveries_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_LARGE_QUEUE_MESSAGES"
-      value = var.large_queue_messages_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_MODULES"
-      value = var.modules_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_POLICY_INPUTS"
-      value = var.policy_inputs_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_RUN_LOGS"
-      value = var.run_logs_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_METADATA"
-      value = var.metadata_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_STATES"
-      value = var.states_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_USER_UPLOADED_WORKSPACES"
-      value = var.user_uploaded_workspaces_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_WORKSPACE"
-      value = var.workspace_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_USAGE_ANALYTICS"
-      value = "" # Unfortunately, it's a required parameter but can be left empty
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_UPLOADS"
-      value = var.uploads_bucket_name
-    },
-    {
-      name  = "OBJECT_STORAGE_BUCKET_UPLOADS_URL"
-      value = var.uploads_bucket_url
-    },
-    {
-      name  = "LICENSE_TYPE"
-      value = "jwt"
-    },
-    {
-      name  = "LICENSE_TOKEN"
-      value = var.license_token
-    },
-    {
-      name  = "OBSERVABILITY_VENDOR"
-      value = var.observability_vendor
-    },
+
+  shared_envs = concat(
+    var.additional_env_vars,
+    [
+      {
+        name  = "AWS_ACCOUNT_ID"
+        value = var.aws_account_id
+      },
+      {
+        name  = "AWS_DEFAULT_REGION"
+        value = var.aws_region
+      },
+      {
+        name  = "AWS_REGION"
+        value = var.aws_region
+      },
+      {
+        name  = "ENVIRONMENT"
+        value = "prod"
+      },
+      {
+        name  = "SERVER_DOMAIN"
+        value = var.server_domain
+      },
+      {
+        name  = "MQTT_BROKER_TYPE"
+        value = var.mqtt_broker_type
+      },
+      {
+        name  = "MQTT_BROKER_ENDPOINT"
+        value = var.mqtt_broker_endpoint
+      },
+      {
+        name  = "ENCRYPTION_TYPE"
+        value = var.encryption_type
+      },
+      {
+        name  = "ENCRYPTION_RSA_PRIVATE_KEY"
+        value = var.rsa_private_key
+      },
+      {
+        name  = "ENCRYPTION_KMS_ENCRYPTION_KEY_ID"
+        value = var.kms_encryption_key_arn
+      },
+      {
+        name  = "ENCRYPTION_KMS_SIGNING_KEY_ID"
+        value = var.kms_signing_key_arn
+      },
+      {
+        name  = "MESSAGE_QUEUE_TYPE"
+        value = var.sqs_queues != null ? "sqs" : "postgres"
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_DELIVERIES"
+        value = var.deliveries_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_LARGE_QUEUE_MESSAGES"
+        value = var.large_queue_messages_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_MODULES"
+        value = var.modules_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_POLICY_INPUTS"
+        value = var.policy_inputs_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_RUN_LOGS"
+        value = var.run_logs_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_METADATA"
+        value = var.metadata_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_STATES"
+        value = var.states_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_USER_UPLOADED_WORKSPACES"
+        value = var.user_uploaded_workspaces_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_WORKSPACE"
+        value = var.workspace_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_USAGE_ANALYTICS"
+        value = ""
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_UPLOADS"
+        value = var.uploads_bucket_name
+      },
+      {
+        name  = "OBJECT_STORAGE_BUCKET_UPLOADS_URL"
+        value = var.uploads_bucket_url
+      },
+      {
+        name  = "LICENSE_TYPE"
+        value = "jwt"
+      },
+      {
+        name  = "LICENSE_TOKEN"
+        value = var.license_token
+      },
+      {
+        name  = "OBSERVABILITY_VENDOR"
+        value = var.observability_vendor
+      }
     ],
     var.database_url != null ? [
       {
@@ -123,6 +127,28 @@ locals {
         value = var.database_read_only_url
       }
     ] : [],
+    var.sqs_queues != null ? [
+      {
+        name  = "MESSAGE_QUEUE_SQS_ASYNC_URL"
+        value = var.sqs_queues.async_jobs_url
+      },
+      {
+        name  = "MESSAGE_QUEUE_SQS_ASYNC_FIFO_URL"
+        value = var.sqs_queues.async_jobs_fifo_url
+      },
+      {
+        name  = "MESSAGE_QUEUE_SQS_CRONJOBS_URL"
+        value = var.sqs_queues.cronjobs_url
+      },
+      {
+        name  = "MESSAGE_QUEUE_SQS_EVENTS_INBOX_URL"
+        value = var.sqs_queues.events_inbox_url
+      },
+      {
+        name  = "MESSAGE_QUEUE_SQS_WEBHOOKS_URL"
+        value = var.sqs_queues.webhooks_url
+      }
+    ] : []
   )
 }
 

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -387,3 +387,37 @@ variable "enable_automatic_usage_data_reporting" {
   type        = bool
   description = "Enable automatic usage data reporting."
 }
+
+variable "mqtt_broker_type" {
+  type        = string
+  description = "The type of MQTT broker to use (builtin or iotcore)."
+}
+
+variable "sqs_queues" {
+  type = object({
+    # ARNs for IAM policies
+    deadletter      = string
+    deadletter_fifo = string
+    async_jobs      = string
+    events_inbox    = string
+    async_jobs_fifo = string
+    cronjobs        = string
+    webhooks        = string
+    iot             = string
+    # URLs for environment variables
+    deadletter_url      = string
+    deadletter_fifo_url = string
+    async_jobs_url      = string
+    events_inbox_url    = string
+    async_jobs_fifo_url = string
+    cronjobs_url        = string
+    webhooks_url        = string
+    iot_url             = string
+  })
+  description = "A map of SQS queue ARNs and URLs, in case the queue type is SQS."
+}
+
+variable "iot_topic" {
+  type        = string
+  description = "The IoT topic when AWS IoT is used as a message broker."
+}

--- a/modules/lb/mqtt_lb.tf
+++ b/modules/lb/mqtt_lb.tf
@@ -1,4 +1,5 @@
 resource "aws_lb" "mqtt" {
+  count              = var.mqtt_broker_type == "builtin" ? 1 : 0
   name               = "spacelift-mqtt-${var.suffix}"
   security_groups    = [aws_security_group.load_balancer_sg.id]
   subnets            = var.mqtt_lb_subnets
@@ -7,6 +8,7 @@ resource "aws_lb" "mqtt" {
 }
 
 resource "aws_lb_target_group" "mqtt" {
+  count       = var.mqtt_broker_type == "builtin" ? 1 : 0
   name        = "spacelift-mqtt-tg-${var.suffix}"
   port        = var.mqtt_port
   protocol    = "TCP"
@@ -15,12 +17,13 @@ resource "aws_lb_target_group" "mqtt" {
 }
 
 resource "aws_lb_listener" "mqtt" {
-  load_balancer_arn = aws_lb.mqtt.arn
+  count             = var.mqtt_broker_type == "builtin" ? 1 : 0
+  load_balancer_arn = aws_lb.mqtt[0].arn
   port              = var.mqtt_port
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.mqtt.arn
+    target_group_arn = aws_lb_target_group.mqtt[0].arn
   }
 }

--- a/modules/lb/outputs.tf
+++ b/modules/lb/outputs.tf
@@ -3,7 +3,7 @@ output "server_lb_dns" {
 }
 
 output "mqtt_lb_dns" {
-  value = aws_lb.mqtt.dns_name
+  value = var.mqtt_broker_type == "builtin" ? aws_lb.mqtt[0].dns_name : null
 }
 
 output "server_target_group_arn" {
@@ -11,5 +11,5 @@ output "server_target_group_arn" {
 }
 
 output "mqtt_target_group_arn" {
-  value = aws_lb_target_group.mqtt.arn
+  value = var.mqtt_broker_type == "builtin" ? aws_lb_target_group.mqtt[0].arn : null
 }

--- a/modules/lb/security.tf
+++ b/modules/lb/security.tf
@@ -15,6 +15,8 @@ resource "aws_vpc_security_group_egress_rule" "lb_http_towards_server" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "lb_mqtt_towards_server" {
+  count = var.mqtt_broker_type == "builtin" ? 1 : 0
+
   security_group_id = aws_security_group.load_balancer_sg.id
 
   description                  = "Allow all traffic to the server"
@@ -35,11 +37,13 @@ resource "aws_vpc_security_group_ingress_rule" "tls" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "mqtt" {
+  count = var.mqtt_broker_type == "builtin" ? 1 : 0
+
   security_group_id = aws_security_group.load_balancer_sg.id
 
   description = "Accept TLS connections on port 1984 for built in MQTT server"
-  from_port   = 1984
-  to_port     = 1984
+  from_port   = var.mqtt_port
+  to_port     = var.mqtt_port
   ip_protocol = "tcp"
   cidr_ipv4   = "0.0.0.0/0"
 }
@@ -55,6 +59,8 @@ resource "aws_vpc_security_group_ingress_rule" "http_lb_to_server" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "mqtt_lb_to_server" {
+  count = var.mqtt_broker_type == "builtin" ? 1 : 0
+
   security_group_id = var.server_security_group_id
 
   description                  = "Allow MQTT connections from the load balancer"

--- a/modules/lb/variables.tf
+++ b/modules/lb/variables.tf
@@ -47,3 +47,8 @@ variable "mqtt_lb_internal" {
   type        = bool
   description = "Whether the MQTT load balancer should be internal or internet-facing."
 }
+
+variable "mqtt_broker_type" {
+  type        = string
+  description = "The type of MQTT broker to use (builtin or iotcore)."
+}


### PR DESCRIPTION
To facilitate the migration path from SH v2 to v3, this PR does the following:

- Replace iot_topic variable with mqtt_broker_type
- Change broker type options from "mqtt" to "builtin"
- Rename mqtt/iotcore references to be more consistent
- Add full SQS and IoT core integration
- Update documentation with configuration options
- Format code to follow style guidelines