### PR TITLE
Inject the license token from a secret to the task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This module creates:
   - An ECS cluster
   - Three services (server, drain, scheduler)
   - IAM roles and policies for the corresponding services
+  - A SecretsManager secret for storing sensitive environment variables, such as the license token
 
 Once it succeeded, don't forget to create a DNS record (`CNAME`) for the server and MQTT load balancer (if using the `builtin` broker type).
 

--- a/modules/ecs/container_definitions.tf
+++ b/modules/ecs/container_definitions.tf
@@ -48,7 +48,15 @@ locals {
           value = local.webhooks_endpoint
         }
       ])
-      secrets = var.sensitive_env_vars
+      secrets = concat(
+        [
+          {
+            name      = "LICENSE_TOKEN",
+            valueFrom = "${aws_secretsmanager_secret.shared_secrets.arn}:LICENSE_TOKEN::"
+          }
+        ],
+        var.sensitive_env_vars
+      )
     }
   ])
 
@@ -97,7 +105,15 @@ locals {
           }
         ] : []
       )
-      secrets = var.sensitive_env_vars
+      secrets = concat(
+        [
+          {
+            name      = "LICENSE_TOKEN",
+            valueFrom = "${aws_secretsmanager_secret.shared_secrets.arn}:LICENSE_TOKEN::"
+          }
+        ],
+        var.sensitive_env_vars
+      )
     }
   ])
 
@@ -116,7 +132,15 @@ locals {
       ]
       logConfiguration = var.scheduler_log_configuration
       environment      = local.shared_envs
-      secrets          = var.sensitive_env_vars
+      secrets = concat(
+        [
+          {
+            name      = "LICENSE_TOKEN",
+            valueFrom = "${aws_secretsmanager_secret.shared_secrets.arn}:LICENSE_TOKEN::"
+          }
+        ],
+        var.sensitive_env_vars
+      )
     }
   ])
 }

--- a/modules/ecs/secrets.tf
+++ b/modules/ecs/secrets.tf
@@ -1,0 +1,9 @@
+resource "aws_secretsmanager_secret" "shared_secrets" {
+  name        = "spacelift/shared-secrets-${var.suffix}"
+  description = "Secrets that are used by the Spacelift ECS services"
+}
+
+resource "aws_secretsmanager_secret_version" "shared_secrets" {
+  secret_id     = aws_secretsmanager_secret.shared_secrets.id
+  secret_string = jsonencode({ LICENSE_TOKEN = var.license_token })
+}

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -111,10 +111,6 @@ locals {
         value = "jwt"
       },
       {
-        name  = "LICENSE_TOKEN"
-        value = var.license_token
-      },
-      {
         name  = "OBSERVABILITY_VENDOR"
         value = var.observability_vendor
       }

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -316,6 +316,7 @@ variable "database_read_only_url" {
 variable "license_token" {
   type        = string
   description = "The license token for selfhosted, issued by Spacelift."
+  sensitive   = true
 }
 
 variable "observability_vendor" {


### PR DESCRIPTION
Instead of having it as plain text.