### PR TITLE
fix: correctly map MQTT load balancer to targets

### DIFF
--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -50,7 +50,7 @@ resource "aws_ecs_service" "server" {
   }
 
   dynamic "load_balancer" {
-    for_each = var.mqtt_broker_type == "mqtt" ? [1] : []
+    for_each = var.mqtt_broker_type == "builtin" ? [1] : []
     content {
       target_group_arn = var.mqtt_server_target_group_arn
       container_name   = "server"


### PR DESCRIPTION
There was a typo in the check that determines whether or not to create a mapping between the MQTT broker target group and the server service. This meant that the targets were not being correctly registered when using the built-in broker.