### PR TITLE
feat: Allow adding BYO target group for the server service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,7 @@ module "ecs" {
   mqtt_broker_type             = local.mqtt_broker_type
   mqtt_broker_endpoint         = local.mqtt_broker_endpoint
   mqtt_server_target_group_arn = module.lb.mqtt_target_group_arn
+  byo_server_target_group_arns = var.byo_server_target_group_arns
 
   database_url           = var.database_url
   database_read_only_url = var.database_read_only_url

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -57,6 +57,15 @@ resource "aws_ecs_service" "server" {
       container_port   = var.mqtt_broker_port
     }
   }
+
+  dynamic "load_balancer" {
+    for_each = toset(var.byo_server_target_group_arns)
+    content {
+      target_group_arn = load_balancer.value
+      container_name   = "server"
+      container_port   = var.server_port
+    }
+  }
 }
 
 resource "aws_ecs_service" "drain" {

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -203,6 +203,12 @@ variable "mqtt_server_target_group_arn" {
   description = "The ARN of the MQTT server target group."
 }
 
+variable "byo_server_target_group_arns" {
+  type        = list(string)
+  description = "The target groups ARNs of the BYO load balancer for server service."
+  default     = []
+}
+
 variable "server_port" {
   type        = number
   description = "The port the server service listens on."

--- a/variables.tf
+++ b/variables.tf
@@ -337,6 +337,12 @@ variable "server_role_arn" {
   default     = null
 }
 
+variable "byo_server_target_group_arns" {
+  type        = list(string)
+  description = "The target groups ARNs of the BYO load balancer for server service."
+  default     = []
+}
+
 variable "vcs_gateway_domain" {
   type        = string
   description = "The domain of the VCS Gateway service. This should be the domain name without the protocol, for example vcs-gateway.example.com, not https://vcs-gateway.example.com."


### PR DESCRIPTION
We have a custom setup where we are adding our own additional Load Balancer. Thus, the ECS service must register into this BYO target group.