### PR TITLE
feat: Add support for write-only secret strings for license token variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,9 @@ module "ecs" {
   launcher_image     = var.launcher_image
   launcher_image_tag = var.launcher_image_tag
 
-  license_token = var.license_token
+  license_token            = var.license_token
+  license_token_wo         = var.license_token_wo
+  license_token_wo_version = var.license_token_wo_version
 
   server_port                  = local.server_port
   mqtt_broker_port             = local.mqtt_port

--- a/modules/ecs/secrets.tf
+++ b/modules/ecs/secrets.tf
@@ -5,6 +5,8 @@ resource "aws_secretsmanager_secret" "shared_secrets" {
 }
 
 resource "aws_secretsmanager_secret_version" "shared_secrets" {
-  secret_id     = aws_secretsmanager_secret.shared_secrets.id
-  secret_string = jsonencode({ LICENSE_TOKEN = var.license_token })
+  secret_id                = aws_secretsmanager_secret.shared_secrets.id
+  secret_string            = var.license_token != null ? jsonencode({ LICENSE_TOKEN = var.license_token }) : null
+  secret_string_wo         = var.license_token_wo != null ? jsonencode({ LICENSE_TOKEN = var.license_token_wo }) : null
+  secret_string_wo_version = var.license_token_wo_version != null ? var.license_token_wo_version : null
 }

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -373,6 +373,18 @@ variable "license_token" {
   sensitive   = true
 }
 
+variable "license_token_wo" {
+  type        = string
+  description = "The license token for selfhosted, issued by Spacelift." # TODO
+  sensitive   = true
+  ephemeral   = true
+}
+
+variable "license_token_wo_version" {
+  type        = number
+  description = "The license token for selfhosted, issued by Spacelift." # TODO
+}
+
 variable "observability_vendor" {
   type        = string
   description = "The observability vendor to use for metrics and logs."

--- a/variables.tf
+++ b/variables.tf
@@ -109,8 +109,23 @@ variable "launcher_image_tag" {
 
 variable "license_token" {
   type        = string
-  description = "The license token for selfhosted, issued by Spacelift."
+  description = "The license token for selfhosted, issued by Spacelift. This cannot be combined with license_token_wo."
   sensitive   = true
+  default     = null
+}
+
+variable "license_token_wo" {
+  type        = string
+  description = "The license token for selfhosted, issued by Spacelift. Saved using write-only attribute. This cannot be combined with license_token."
+  sensitive   = true
+  ephemeral   = true
+  default     = null
+}
+
+variable "license_token_wo_version" {
+  type        = number
+  description = "The license token for selfhosted, issued by Spacelift. This is required if license_token_wo is set."
+  default     = null
 }
 
 variable "database_url" {


### PR DESCRIPTION
SUpports both `secret_string` and `secret_string_wo` + `secret_string_wo_version` attributes.