### PR TITLE
feat: Add server ALB ARN to output

### DIFF
--- a/modules/lb/outputs.tf
+++ b/modules/lb/outputs.tf
@@ -2,6 +2,10 @@ output "server_lb_dns" {
   value = aws_lb.server.dns_name
 }
 
+output "server_lb_arn" {
+  value = aws_lb.server.arn
+}
+
 output "mqtt_lb_dns" {
   value = var.mqtt_broker_type == "builtin" ? aws_lb.mqtt[0].dns_name : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "server_lb_dns_name" {
   description = "The DNS name of the server load balancer"
 }
 
+output "server_lb_arn" {
+  value       = module.lb.server_lb_arn
+  description = "The ARN of the server load balancer"
+}
+
 output "mqtt_lb_dns_name" {
   value       = module.lb.mqtt_lb_dns
   description = "The DNS name of the mqtt load balancer"


### PR DESCRIPTION
We attach Network Load Balancer to the Spacelift Application Load Balancer. To make this possible, we have added the ALB ARN to the output.