### PR TITLE
remove vcs checks to allow the configuration to be optional

### DIFF
--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -62,10 +62,6 @@ variable "drain_desired_count" {
 variable "vcs_gateway_domain" {
   type        = string
   description = "The domain of the VCS Gateway service. This should be the domain name without the protocol, for example vcs-gateway.example.com, not https://vcs-gateway.example.com."
-  validation {
-    condition     = var.vcs_gateway_domain == null || (!startswith(var.vcs_gateway_domain, "http://") && !startswith(var.vcs_gateway_domain, "https://"))
-    error_message = "vcs_gateway_domain should not include a protocol ('http://' or 'https://')"
-  }
 }
 
 variable "vcs_gateway_security_group_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -347,10 +347,6 @@ variable "vcs_gateway_domain" {
   type        = string
   description = "The domain of the VCS Gateway service. This should be the domain name without the protocol, for example vcs-gateway.example.com, not https://vcs-gateway.example.com."
   default     = null
-  validation {
-    condition     = var.vcs_gateway_domain == null || (!startswith(var.vcs_gateway_domain, "http://") && !startswith(var.vcs_gateway_domain, "https://"))
-    error_message = "vcs_gateway_domain should not include a protocol ('http://' or 'https://')"
-  }
 }
 
 variable "vcs_gateway_log_configuration" {


### PR DESCRIPTION
In order to be able to use the v1.4.0 version (which I want to use b/c it exposes the load balancer arn as an output), I needed to remove validation that was failing on tofu 1.9 where the version does not allow vcs_gateway_domain to be optional

I'm a little confused at why it would evaluate the startswith expressions if var.vcs_gateway_domain is null, I didn't really look into it, just removed the validation since I wasn't using the capability

```
│ Error: Invalid function argument
│
│   on .terraform/modules/plt_self_hosted.self_hosted_infra.spacelift_services/variables.tf line 351, in variable "vcs_gateway_domain":
│  351:     condition     = var.vcs_gateway_domain == null || (!startswith(var.vcs_gateway_domain, "http://") && !startswith(var.vcs_gateway_domain, "https://"))
│     ├────────────────
│     │ while calling startswith(str, prefix)
│     │ var.vcs_gateway_domain is null
│
│ Invalid value for "str" parameter: argument must not be null.
```