### PR TITLE
fix(ecs): let additional_env_vars override module defaults

### DIFF
--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -6,8 +6,7 @@ locals {
   # Determine observability vendor based on enabled sidecars
   observability_vendor = var.enable_datadog_agent_sidecar ? "Datadog" : (var.enable_otel_sidecar ? "OpenTelemetry" : var.observability_vendor)
 
-  shared_envs = concat(
-    var.additional_env_vars,
+  default_envs = concat(
     [
       {
         name  = "AWS_ACCOUNT_ID"
@@ -159,6 +158,11 @@ locals {
       }
     ] : []
   )
+
+  shared_envs = values(merge(
+    { for e in local.default_envs : e.name => e },
+    { for e in var.additional_env_vars : e.name => e },
+  ))
 }
 
 module "container_definitions" {


### PR DESCRIPTION
`concat` happily produces duplicate entries when a caller passes an env var whose name already exists in the module's defaults. ECS keeps the first occurrence, so user overrides were being silently shadowed.

Switch to a map merge keyed by `name` so `additional_env_vars` wins on collision, with the defaults still applied for everything else.