### PR TITLE
feat: per-queue drain concurrency variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,14 @@ module "ecs" {
   drain_security_group        = var.drain_security_group_id
   drain_container_definitions = var.drain_container_definitions
 
-  drain_concurrency = var.drain_concurrency
+  drain_concurrency_async_jobs      = var.drain_concurrency_async_jobs
+  drain_concurrency_async_jobs_fifo = var.drain_concurrency_async_jobs_fifo
+  drain_concurrency_cronjobs        = var.drain_concurrency_cronjobs
+  drain_concurrency_dlq             = var.drain_concurrency_dlq
+  drain_concurrency_dlq_fifo        = var.drain_concurrency_dlq_fifo
+  drain_concurrency_events          = var.drain_concurrency_events
+  drain_concurrency_iot             = var.drain_concurrency_iot
+  drain_concurrency_webhooks        = var.drain_concurrency_webhooks
 
   scheduler_cpu                  = var.scheduler_cpu
   scheduler_desired_count        = var.scheduler_desired_count

--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,15 @@ module "ecs" {
   drain_security_group        = var.drain_security_group_id
   drain_container_definitions = var.drain_container_definitions
 
+  drain_concurrency_async_jobs      = var.drain_concurrency_async_jobs
+  drain_concurrency_async_jobs_fifo = var.drain_concurrency_async_jobs_fifo
+  drain_concurrency_cronjobs        = var.drain_concurrency_cronjobs
+  drain_concurrency_dlq             = var.drain_concurrency_dlq
+  drain_concurrency_dlq_fifo        = var.drain_concurrency_dlq_fifo
+  drain_concurrency_events          = var.drain_concurrency_events
+  drain_concurrency_iot             = var.drain_concurrency_iot
+  drain_concurrency_webhooks        = var.drain_concurrency_webhooks
+
   scheduler_cpu                  = var.scheduler_cpu
   scheduler_desired_count        = var.scheduler_desired_count
   scheduler_log_configuration    = var.scheduler_log_configuration

--- a/main.tf
+++ b/main.tf
@@ -131,14 +131,7 @@ module "ecs" {
   drain_security_group        = var.drain_security_group_id
   drain_container_definitions = var.drain_container_definitions
 
-  drain_concurrency_async_jobs      = var.drain_concurrency_async_jobs
-  drain_concurrency_async_jobs_fifo = var.drain_concurrency_async_jobs_fifo
-  drain_concurrency_cronjobs        = var.drain_concurrency_cronjobs
-  drain_concurrency_dlq             = var.drain_concurrency_dlq
-  drain_concurrency_dlq_fifo        = var.drain_concurrency_dlq_fifo
-  drain_concurrency_events          = var.drain_concurrency_events
-  drain_concurrency_iot             = var.drain_concurrency_iot
-  drain_concurrency_webhooks        = var.drain_concurrency_webhooks
+  drain_concurrency = var.drain_concurrency
 
   scheduler_cpu                  = var.scheduler_cpu
   scheduler_desired_count        = var.scheduler_desired_count

--- a/modules/ecs/container_definitions/drain.tf
+++ b/modules/ecs/container_definitions/drain.tf
@@ -42,6 +42,38 @@ locals {
               {
                 name  = "SPACELIFT_PUBLIC_API"
                 value = var.enable_automatic_usage_data_reporting ? local.spacelift_public_api : ""
+              },
+              {
+                name  = "DRAIN_CONCURRENCY_ASYNC_JOBS"
+                value = tostring(var.drain_concurrency_async_jobs)
+              },
+              {
+                name  = "DRAIN_CONCURRENCY_ASYNC_JOBS_FIFO"
+                value = tostring(var.drain_concurrency_async_jobs_fifo)
+              },
+              {
+                name  = "DRAIN_CONCURRENCY_CRONJOBS"
+                value = tostring(var.drain_concurrency_cronjobs)
+              },
+              {
+                name  = "DRAIN_CONCURRENCY_DLQ"
+                value = tostring(var.drain_concurrency_dlq)
+              },
+              {
+                name  = "DRAIN_CONCURRENCY_DLQ_FIFO"
+                value = tostring(var.drain_concurrency_dlq_fifo)
+              },
+              {
+                name  = "DRAIN_CONCURRENCY_EVENTS"
+                value = tostring(var.drain_concurrency_events)
+              },
+              {
+                name  = "DRAIN_CONCURRENCY_IOT"
+                value = tostring(var.drain_concurrency_iot)
+              },
+              {
+                name  = "DRAIN_CONCURRENCY_WEBHOOKS"
+                value = tostring(var.drain_concurrency_webhooks)
               }
             ],
             var.sqs_queues != null ? [

--- a/modules/ecs/container_definitions/drain.tf
+++ b/modules/ecs/container_definitions/drain.tf
@@ -45,35 +45,35 @@ locals {
               },
               {
                 name  = "DRAIN_CONCURRENCY_ASYNC_JOBS"
-                value = tostring(var.drain_concurrency_async_jobs)
+                value = tostring(var.drain_concurrency.async_jobs)
               },
               {
                 name  = "DRAIN_CONCURRENCY_ASYNC_JOBS_FIFO"
-                value = tostring(var.drain_concurrency_async_jobs_fifo)
+                value = tostring(var.drain_concurrency.async_jobs_fifo)
               },
               {
                 name  = "DRAIN_CONCURRENCY_CRONJOBS"
-                value = tostring(var.drain_concurrency_cronjobs)
+                value = tostring(var.drain_concurrency.cronjobs)
               },
               {
                 name  = "DRAIN_CONCURRENCY_DLQ"
-                value = tostring(var.drain_concurrency_dlq)
+                value = tostring(var.drain_concurrency.dlq)
               },
               {
                 name  = "DRAIN_CONCURRENCY_DLQ_FIFO"
-                value = tostring(var.drain_concurrency_dlq_fifo)
+                value = tostring(var.drain_concurrency.dlq_fifo)
               },
               {
                 name  = "DRAIN_CONCURRENCY_EVENTS"
-                value = tostring(var.drain_concurrency_events)
+                value = tostring(var.drain_concurrency.events)
               },
               {
                 name  = "DRAIN_CONCURRENCY_IOT"
-                value = tostring(var.drain_concurrency_iot)
+                value = tostring(var.drain_concurrency.iot)
               },
               {
                 name  = "DRAIN_CONCURRENCY_WEBHOOKS"
-                value = tostring(var.drain_concurrency_webhooks)
+                value = tostring(var.drain_concurrency.webhooks)
               }
             ],
             var.sqs_queues != null ? [

--- a/modules/ecs/container_definitions/drain.tf
+++ b/modules/ecs/container_definitions/drain.tf
@@ -45,35 +45,35 @@ locals {
               },
               {
                 name  = "DRAIN_CONCURRENCY_ASYNC_JOBS"
-                value = tostring(var.drain_concurrency.async_jobs)
+                value = tostring(var.drain_concurrency_async_jobs)
               },
               {
                 name  = "DRAIN_CONCURRENCY_ASYNC_JOBS_FIFO"
-                value = tostring(var.drain_concurrency.async_jobs_fifo)
+                value = tostring(var.drain_concurrency_async_jobs_fifo)
               },
               {
                 name  = "DRAIN_CONCURRENCY_CRONJOBS"
-                value = tostring(var.drain_concurrency.cronjobs)
+                value = tostring(var.drain_concurrency_cronjobs)
               },
               {
                 name  = "DRAIN_CONCURRENCY_DLQ"
-                value = tostring(var.drain_concurrency.dlq)
+                value = tostring(var.drain_concurrency_dlq)
               },
               {
                 name  = "DRAIN_CONCURRENCY_DLQ_FIFO"
-                value = tostring(var.drain_concurrency.dlq_fifo)
+                value = tostring(var.drain_concurrency_dlq_fifo)
               },
               {
                 name  = "DRAIN_CONCURRENCY_EVENTS"
-                value = tostring(var.drain_concurrency.events)
+                value = tostring(var.drain_concurrency_events)
               },
               {
                 name  = "DRAIN_CONCURRENCY_IOT"
-                value = tostring(var.drain_concurrency.iot)
+                value = tostring(var.drain_concurrency_iot)
               },
               {
                 name  = "DRAIN_CONCURRENCY_WEBHOOKS"
-                value = tostring(var.drain_concurrency.webhooks)
+                value = tostring(var.drain_concurrency_webhooks)
               }
             ],
             var.sqs_queues != null ? [

--- a/modules/ecs/container_definitions/variables.tf
+++ b/modules/ecs/container_definitions/variables.tf
@@ -39,6 +39,46 @@ variable "drain_log_configuration" {
   description = "Log configuration for drain container"
 }
 
+variable "drain_concurrency_async_jobs" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs queue per drain task."
+}
+
+variable "drain_concurrency_async_jobs_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs.fifo queue per drain task."
+}
+
+variable "drain_concurrency_cronjobs" {
+  type        = number
+  description = "Number of concurrent receivers for the cronjobs queue per drain task."
+}
+
+variable "drain_concurrency_dlq" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ queue per drain task."
+}
+
+variable "drain_concurrency_dlq_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ FIFO queue per drain task."
+}
+
+variable "drain_concurrency_events" {
+  type        = number
+  description = "Number of concurrent receivers for the events-inbox queue per drain task."
+}
+
+variable "drain_concurrency_iot" {
+  type        = number
+  description = "Number of concurrent receivers for the IoT queue per drain task."
+}
+
+variable "drain_concurrency_webhooks" {
+  type        = number
+  description = "Number of concurrent receivers for the webhooks queue per drain task."
+}
+
 variable "scheduler_log_configuration" {
   type        = any
   description = "Log configuration for scheduler container"

--- a/modules/ecs/container_definitions/variables.tf
+++ b/modules/ecs/container_definitions/variables.tf
@@ -39,18 +39,44 @@ variable "drain_log_configuration" {
   description = "Log configuration for drain container"
 }
 
-variable "drain_concurrency" {
-  type = object({
-    async_jobs      = optional(number, 1)
-    async_jobs_fifo = optional(number, 1)
-    cronjobs        = optional(number, 1)
-    dlq             = optional(number, 1)
-    dlq_fifo        = optional(number, 1)
-    events          = optional(number, 1)
-    iot             = optional(number, 1)
-    webhooks        = optional(number, 1)
-  })
-  description = "Per-queue concurrent receivers for the drain task."
+variable "drain_concurrency_async_jobs" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs queue per drain pod."
+}
+
+variable "drain_concurrency_async_jobs_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs.fifo queue per drain pod."
+}
+
+variable "drain_concurrency_cronjobs" {
+  type        = number
+  description = "Number of concurrent receivers for the cronjobs queue per drain pod."
+}
+
+variable "drain_concurrency_dlq" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ queue per drain pod."
+}
+
+variable "drain_concurrency_dlq_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ FIFO queue per drain pod."
+}
+
+variable "drain_concurrency_events" {
+  type        = number
+  description = "Number of concurrent receivers for the events-inbox queue per drain pod."
+}
+
+variable "drain_concurrency_iot" {
+  type        = number
+  description = "Number of concurrent receivers for the IoT queue per drain pod."
+}
+
+variable "drain_concurrency_webhooks" {
+  type        = number
+  description = "Number of concurrent receivers for the webhooks queue per drain pod."
 }
 
 variable "scheduler_log_configuration" {

--- a/modules/ecs/container_definitions/variables.tf
+++ b/modules/ecs/container_definitions/variables.tf
@@ -39,44 +39,18 @@ variable "drain_log_configuration" {
   description = "Log configuration for drain container"
 }
 
-variable "drain_concurrency_async_jobs" {
-  type        = number
-  description = "Number of concurrent receivers for the async-jobs queue per drain task."
-}
-
-variable "drain_concurrency_async_jobs_fifo" {
-  type        = number
-  description = "Number of concurrent receivers for the async-jobs.fifo queue per drain task."
-}
-
-variable "drain_concurrency_cronjobs" {
-  type        = number
-  description = "Number of concurrent receivers for the cronjobs queue per drain task."
-}
-
-variable "drain_concurrency_dlq" {
-  type        = number
-  description = "Number of concurrent receivers for the DLQ queue per drain task."
-}
-
-variable "drain_concurrency_dlq_fifo" {
-  type        = number
-  description = "Number of concurrent receivers for the DLQ FIFO queue per drain task."
-}
-
-variable "drain_concurrency_events" {
-  type        = number
-  description = "Number of concurrent receivers for the events-inbox queue per drain task."
-}
-
-variable "drain_concurrency_iot" {
-  type        = number
-  description = "Number of concurrent receivers for the IoT queue per drain task."
-}
-
-variable "drain_concurrency_webhooks" {
-  type        = number
-  description = "Number of concurrent receivers for the webhooks queue per drain task."
+variable "drain_concurrency" {
+  type = object({
+    async_jobs      = optional(number, 1)
+    async_jobs_fifo = optional(number, 1)
+    cronjobs        = optional(number, 1)
+    dlq             = optional(number, 1)
+    dlq_fifo        = optional(number, 1)
+    events          = optional(number, 1)
+    iot             = optional(number, 1)
+    webhooks        = optional(number, 1)
+  })
+  description = "Per-queue concurrent receivers for the drain task."
 }
 
 variable "scheduler_log_configuration" {

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -182,14 +182,7 @@ module "container_definitions" {
   vcs_gateway_internal_port     = var.vcs_gateway_internal_port
 
   # Drain per-queue concurrency
-  drain_concurrency_async_jobs      = var.drain_concurrency_async_jobs
-  drain_concurrency_async_jobs_fifo = var.drain_concurrency_async_jobs_fifo
-  drain_concurrency_cronjobs        = var.drain_concurrency_cronjobs
-  drain_concurrency_dlq             = var.drain_concurrency_dlq
-  drain_concurrency_dlq_fifo        = var.drain_concurrency_dlq_fifo
-  drain_concurrency_events          = var.drain_concurrency_events
-  drain_concurrency_iot             = var.drain_concurrency_iot
-  drain_concurrency_webhooks        = var.drain_concurrency_webhooks
+  drain_concurrency = var.drain_concurrency
 
   # Authentication
   admin_username = var.admin_username

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -182,7 +182,14 @@ module "container_definitions" {
   vcs_gateway_internal_port     = var.vcs_gateway_internal_port
 
   # Drain per-queue concurrency
-  drain_concurrency = var.drain_concurrency
+  drain_concurrency_async_jobs      = var.drain_concurrency_async_jobs
+  drain_concurrency_async_jobs_fifo = var.drain_concurrency_async_jobs_fifo
+  drain_concurrency_cronjobs        = var.drain_concurrency_cronjobs
+  drain_concurrency_dlq             = var.drain_concurrency_dlq
+  drain_concurrency_dlq_fifo        = var.drain_concurrency_dlq_fifo
+  drain_concurrency_events          = var.drain_concurrency_events
+  drain_concurrency_iot             = var.drain_concurrency_iot
+  drain_concurrency_webhooks        = var.drain_concurrency_webhooks
 
   # Authentication
   admin_username = var.admin_username

--- a/modules/ecs/task_definitions.tf
+++ b/modules/ecs/task_definitions.tf
@@ -181,6 +181,16 @@ module "container_definitions" {
   vcs_gateway_external_port     = var.vcs_gateway_external_port
   vcs_gateway_internal_port     = var.vcs_gateway_internal_port
 
+  # Drain per-queue concurrency
+  drain_concurrency_async_jobs      = var.drain_concurrency_async_jobs
+  drain_concurrency_async_jobs_fifo = var.drain_concurrency_async_jobs_fifo
+  drain_concurrency_cronjobs        = var.drain_concurrency_cronjobs
+  drain_concurrency_dlq             = var.drain_concurrency_dlq
+  drain_concurrency_dlq_fifo        = var.drain_concurrency_dlq_fifo
+  drain_concurrency_events          = var.drain_concurrency_events
+  drain_concurrency_iot             = var.drain_concurrency_iot
+  drain_concurrency_webhooks        = var.drain_concurrency_webhooks
+
   # Authentication
   admin_username = var.admin_username
   admin_password = var.admin_password

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -136,7 +136,7 @@ variable "drain_concurrency" {
     webhooks        = optional(number, 1)
   })
   default     = {}
-  description = "Per-queue concurrent receivers for the drain task. Defaults to 1 per queue (behaviour-preserving)."
+  description = "Per-queue concurrent receivers for the drain task."
 }
 
 variable "server_security_group" {

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -124,6 +124,54 @@ variable "drain_security_group" {
   description = "The security group to attach to the drain service."
 }
 
+variable "drain_concurrency_async_jobs" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_async_jobs_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs.fifo queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_cronjobs" {
+  type        = number
+  description = "Number of concurrent receivers for the cronjobs queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_dlq" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_dlq_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ FIFO queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_events" {
+  type        = number
+  description = "Number of concurrent receivers for the events-inbox queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_iot" {
+  type        = number
+  description = "Number of concurrent receivers for the IoT queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_webhooks" {
+  type        = number
+  description = "Number of concurrent receivers for the webhooks queue per drain task."
+  default     = 1
+}
+
 variable "server_security_group" {
   type        = string
   description = "The security group to attach to the server service."

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -124,19 +124,44 @@ variable "drain_security_group" {
   description = "The security group to attach to the drain service."
 }
 
-variable "drain_concurrency" {
-  type = object({
-    async_jobs      = optional(number, 1)
-    async_jobs_fifo = optional(number, 1)
-    cronjobs        = optional(number, 1)
-    dlq             = optional(number, 1)
-    dlq_fifo        = optional(number, 1)
-    events          = optional(number, 1)
-    iot             = optional(number, 1)
-    webhooks        = optional(number, 1)
-  })
-  default     = {}
-  description = "Per-queue concurrent receivers for the drain task."
+variable "drain_concurrency_async_jobs" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs queue per drain pod."
+}
+
+variable "drain_concurrency_async_jobs_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs.fifo queue per drain pod."
+}
+
+variable "drain_concurrency_cronjobs" {
+  type        = number
+  description = "Number of concurrent receivers for the cronjobs queue per drain pod."
+}
+
+variable "drain_concurrency_dlq" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ queue per drain pod."
+}
+
+variable "drain_concurrency_dlq_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ FIFO queue per drain pod."
+}
+
+variable "drain_concurrency_events" {
+  type        = number
+  description = "Number of concurrent receivers for the events-inbox queue per drain pod."
+}
+
+variable "drain_concurrency_iot" {
+  type        = number
+  description = "Number of concurrent receivers for the IoT queue per drain pod."
+}
+
+variable "drain_concurrency_webhooks" {
+  type        = number
+  description = "Number of concurrent receivers for the webhooks queue per drain pod."
 }
 
 variable "server_security_group" {

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -124,52 +124,19 @@ variable "drain_security_group" {
   description = "The security group to attach to the drain service."
 }
 
-variable "drain_concurrency_async_jobs" {
-  type        = number
-  description = "Number of concurrent receivers for the async-jobs queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_async_jobs_fifo" {
-  type        = number
-  description = "Number of concurrent receivers for the async-jobs.fifo queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_cronjobs" {
-  type        = number
-  description = "Number of concurrent receivers for the cronjobs queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_dlq" {
-  type        = number
-  description = "Number of concurrent receivers for the DLQ queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_dlq_fifo" {
-  type        = number
-  description = "Number of concurrent receivers for the DLQ FIFO queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_events" {
-  type        = number
-  description = "Number of concurrent receivers for the events-inbox queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_iot" {
-  type        = number
-  description = "Number of concurrent receivers for the IoT queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_webhooks" {
-  type        = number
-  description = "Number of concurrent receivers for the webhooks queue per drain task."
-  default     = 1
+variable "drain_concurrency" {
+  type = object({
+    async_jobs      = optional(number, 1)
+    async_jobs_fifo = optional(number, 1)
+    cronjobs        = optional(number, 1)
+    dlq             = optional(number, 1)
+    dlq_fifo        = optional(number, 1)
+    events          = optional(number, 1)
+    iot             = optional(number, 1)
+    webhooks        = optional(number, 1)
+  })
+  default     = {}
+  description = "Per-queue concurrent receivers for the drain task. Defaults to 1 per queue (behaviour-preserving)."
 }
 
 variable "server_security_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -257,52 +257,19 @@ variable "drain_security_group_id" {
   description = "The security group ID to use for the drain service."
 }
 
-variable "drain_concurrency_async_jobs" {
-  type        = number
-  description = "Number of concurrent receivers for the async-jobs queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_async_jobs_fifo" {
-  type        = number
-  description = "Number of concurrent receivers for the async-jobs.fifo queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_cronjobs" {
-  type        = number
-  description = "Number of concurrent receivers for the cronjobs queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_dlq" {
-  type        = number
-  description = "Number of concurrent receivers for the DLQ queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_dlq_fifo" {
-  type        = number
-  description = "Number of concurrent receivers for the DLQ FIFO queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_events" {
-  type        = number
-  description = "Number of concurrent receivers for the events-inbox queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_iot" {
-  type        = number
-  description = "Number of concurrent receivers for the IoT queue per drain task."
-  default     = 1
-}
-
-variable "drain_concurrency_webhooks" {
-  type        = number
-  description = "Number of concurrent receivers for the webhooks queue per drain task."
-  default     = 1
+variable "drain_concurrency" {
+  type = object({
+    async_jobs      = optional(number, 1)
+    async_jobs_fifo = optional(number, 1)
+    cronjobs        = optional(number, 1)
+    dlq             = optional(number, 1)
+    dlq_fifo        = optional(number, 1)
+    events          = optional(number, 1)
+    iot             = optional(number, 1)
+    webhooks        = optional(number, 1)
+  })
+  default     = {}
+  description = "Per-queue concurrent receivers for the drain task. Defaults to 1 per queue (behaviour-preserving)."
 }
 
 variable "scheduler_container_definition" {

--- a/variables.tf
+++ b/variables.tf
@@ -257,19 +257,52 @@ variable "drain_security_group_id" {
   description = "The security group ID to use for the drain service."
 }
 
-variable "drain_concurrency" {
-  type = object({
-    async_jobs      = optional(number, 1)
-    async_jobs_fifo = optional(number, 1)
-    cronjobs        = optional(number, 1)
-    dlq             = optional(number, 1)
-    dlq_fifo        = optional(number, 1)
-    events          = optional(number, 1)
-    iot             = optional(number, 1)
-    webhooks        = optional(number, 1)
-  })
-  default     = {}
-  description = "Per-queue concurrent receivers for the drain task."
+variable "drain_concurrency_async_jobs" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs queue per drain pod."
+  default     = 1
+}
+
+variable "drain_concurrency_async_jobs_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs.fifo queue per drain pod."
+  default     = 1
+}
+
+variable "drain_concurrency_cronjobs" {
+  type        = number
+  description = "Number of concurrent receivers for the cronjobs queue per drain pod."
+  default     = 1
+}
+
+variable "drain_concurrency_dlq" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ queue per drain pod."
+  default     = 1
+}
+
+variable "drain_concurrency_dlq_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ FIFO queue per drain pod."
+  default     = 1
+}
+
+variable "drain_concurrency_events" {
+  type        = number
+  description = "Number of concurrent receivers for the events-inbox queue per drain pod."
+  default     = 1
+}
+
+variable "drain_concurrency_iot" {
+  type        = number
+  description = "Number of concurrent receivers for the IoT queue per drain pod."
+  default     = 1
+}
+
+variable "drain_concurrency_webhooks" {
+  type        = number
+  description = "Number of concurrent receivers for the webhooks queue per drain pod."
+  default     = 1
 }
 
 variable "scheduler_container_definition" {

--- a/variables.tf
+++ b/variables.tf
@@ -257,6 +257,54 @@ variable "drain_security_group_id" {
   description = "The security group ID to use for the drain service."
 }
 
+variable "drain_concurrency_async_jobs" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_async_jobs_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the async-jobs.fifo queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_cronjobs" {
+  type        = number
+  description = "Number of concurrent receivers for the cronjobs queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_dlq" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_dlq_fifo" {
+  type        = number
+  description = "Number of concurrent receivers for the DLQ FIFO queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_events" {
+  type        = number
+  description = "Number of concurrent receivers for the events-inbox queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_iot" {
+  type        = number
+  description = "Number of concurrent receivers for the IoT queue per drain task."
+  default     = 1
+}
+
+variable "drain_concurrency_webhooks" {
+  type        = number
+  description = "Number of concurrent receivers for the webhooks queue per drain task."
+  default     = 1
+}
+
 variable "scheduler_container_definition" {
   type        = string
   description = "The container definition for the scheduler service. If empty, a default container definition will be used."

--- a/variables.tf
+++ b/variables.tf
@@ -269,7 +269,7 @@ variable "drain_concurrency" {
     webhooks        = optional(number, 1)
   })
   default     = {}
-  description = "Per-queue concurrent receivers for the drain task. Defaults to 1 per queue (behaviour-preserving)."
+  description = "Per-queue concurrent receivers for the drain task."
 }
 
 variable "scheduler_container_definition" {


### PR DESCRIPTION
Adds a single `drain_concurrency` Terraform variable (object-typed, with `optional(number, 1)` per queue) that injects `DRAIN_CONCURRENCY_*` env vars into the drain ECS task. Lets ECS-on-Terraform operators run N independent receivers per SQS queue in a single drain pod instead of the fixed one-per-queue. Defaults to 1 — opt-in, backwards-compatible.

Variable shape follows this repo's prevailing pattern (`datadog_agent_config` / `otel_config` from #44) rather than the flat-variable style used in the EKS/Azure/GCP modules — the K8s-Secret-via-tftpl constraint that forces flat vars there does not apply here.
